### PR TITLE
Added support for parsing fields that are in ULs. 

### DIFF
--- a/src/test/java/com/ontometrics/scraper/ListingDetailScraperTest.java
+++ b/src/test/java/com/ontometrics/scraper/ListingDetailScraperTest.java
@@ -18,7 +18,6 @@ import org.slf4j.LoggerFactory;
 import com.ontometrics.scraper.extraction.DefaultFieldExtractor;
 import com.ontometrics.scraper.extraction.Link;
 import com.ontometrics.scraper.extraction.LinkExtractor;
-import com.ontometrics.scraper.legacy.Scraper;
 
 public class ListingDetailScraperTest {
 

--- a/src/test/java/com/ontometrics/scraper/extraction/DefaultFieldExtractorTest.java
+++ b/src/test/java/com/ontometrics/scraper/extraction/DefaultFieldExtractorTest.java
@@ -14,6 +14,10 @@ import org.junit.Test;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.ontometrics.scraper.Record;
+import com.ontometrics.scraper.ScrapedRecord;
+import static com.ontometrics.scraper.grants.GrantHtmlSample.*;
+
 public class DefaultFieldExtractorTest {
 
 	private static final Logger log = LoggerFactory.getLogger(DefaultFieldExtractorTest.class);
@@ -26,6 +30,19 @@ public class DefaultFieldExtractorTest {
 
 		assertThat(fields.size(), is(greaterThan(0)));
 		log.debug("fields = {}", fields);
+
+	}
+
+	@Test
+	public void extractsFieldsFromULs() {
+
+		List<Field> fields = fieldExtractor.source(html().url(GrantsnetDetailPage.getUrl())).getFields();
+
+		assertThat(fields.size(), is(greaterThan(0)));
+		Record record = new ScrapedRecord(fields);
+
+		Field fieldFromUL = new ScrapedField("Application deadline(s)", "07/13/2010");
+		assertThat(record.getFields().contains(fieldFromUL), is(true));
 
 	}
 


### PR DESCRIPTION
For now, made it so that if it finds two pieces of text separated by a :, it will parse that as a field. Can add support for other delimiter detection of course.
